### PR TITLE
Fix minimum RPM for original UNI FAN SL controller

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 src/bin
 src/obj
+tests/**/bin
+tests/**/obj
 src/FanControl.LianLiPlugin.csproj.user
 src/.vs

--- a/README.md
+++ b/README.md
@@ -28,6 +28,31 @@ An unofficial LianLi plugin for [FanControl](https://github.com/Rem0o/FanControl
 
 1. Sharing the controllers across multiple pieces of software at the same time will lead to issues. For example, using this plugin along with OpenRGB. If you want to dynamically change the RGB, please use **FanControl.LianLiPlugin.ARGB.dll** and connect the controller to your motherboard's ARGB header.
 
+## Original UNI FAN SL minimum RPM
+
+The original percentage conversion maps 0% to raw `42`. USB captures from
+L-Connect 3 show that an original UNI FAN SL controller with PID `a100`
+instead uses raw `10` as its minimum-running command on every channel:
+
+```text
+E0 20 00 0A
+E0 21 00 0A
+E0 22 00 0A
+E0 23 00 0A
+```
+
+On the tested hub, this produced approximately 495 RPM with SL140 fans and
+780-810 RPM with SL120 fans. This plugin therefore maps 0% to raw `10` only
+for PID `a100`. Values above 0% and all other supported controller PIDs keep
+their existing mappings. Raw zero is never sent, and 100% remains full speed.
+
+Mapping tests can be built and run with:
+
+```powershell
+msbuild src\FanControl.LianLiPlugin.sln /t:Build /p:Configuration=Release /p:Platform="Any CPU"
+tests\FanControl.LianLiPlugin.Tests\bin\Release\FanControl.LianLiPlugin.Tests.exe
+```
+
 ## Submitting An Issue
 
 When submitting an issue, please include the Name, VID, and PID of your controller. It can be located within Device Manager:

--- a/src/FanControl.LianLiPlugin.csproj
+++ b/src/FanControl.LianLiPlugin.csproj
@@ -63,6 +63,7 @@
     <Reference Include="System.Windows.Forms" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="LianLiPlugin\LianLi\FanSpeedMapper.cs" />
     <Compile Include="LianLiPlugin\LianLi\Devices.cs" />
     <Compile Include="LianLiPlugin\LianLi\HID.cs" />
     <Compile Include="LianLiPlugin\LianLi\HidSharp\AsyncResult.cs" />

--- a/src/FanControl.LianLiPlugin.sln
+++ b/src/FanControl.LianLiPlugin.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 17.6.33723.286
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FanControl.LianLiPlugin", "FanControl.LianLiPlugin.csproj", "{456FC2A8-E10A-4B1B-8F8B-64540574E62B}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FanControl.LianLiPlugin.Tests", "..\tests\FanControl.LianLiPlugin.Tests\FanControl.LianLiPlugin.Tests.csproj", "{E3B23066-E5A2-4B47-B999-C92C83C15994}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -21,6 +23,12 @@ Global
 		{456FC2A8-E10A-4B1B-8F8B-64540574E62B}.Release|Any CPU.Build.0 = Release|Any CPU
 		{456FC2A8-E10A-4B1B-8F8B-64540574E62B}.Release|x64.ActiveCfg = Release|x64
 		{456FC2A8-E10A-4B1B-8F8B-64540574E62B}.Release|x64.Build.0 = Release|x64
+		{E3B23066-E5A2-4B47-B999-C92C83C15994}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E3B23066-E5A2-4B47-B999-C92C83C15994}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E3B23066-E5A2-4B47-B999-C92C83C15994}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{E3B23066-E5A2-4B47-B999-C92C83C15994}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E3B23066-E5A2-4B47-B999-C92C83C15994}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E3B23066-E5A2-4B47-B999-C92C83C15994}.Release|x64.ActiveCfg = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/LianLiPlugin/LianLi/Devices.cs
+++ b/src/LianLiPlugin/LianLi/Devices.cs
@@ -50,7 +50,7 @@ namespace LianLi
             return _fancontrollers[fancontroller_index].GetSpeed(fancontroller_channel);
         }
 
-        public void FanControllers_SetSpeed(int fancontroller_index, int fancontroller_channel, int speed)
+        public void FanControllers_SetSpeed(int fancontroller_index, int fancontroller_channel, float speed)
         {
             _fancontrollers[fancontroller_index].SetSpeed(fancontroller_channel, speed);
         }
@@ -104,28 +104,26 @@ namespace LianLi
         }
 
 
-        public void SetSpeed(int fancontroller_channel, int speed)
+        public void SetSpeed(int fancontroller_channel, float speed)
         {
-            var speed_800_1900 = (byte)((800 + (11 * speed)) / 19);
-            var speed_250_2000 = (byte)((250 + (17.5 * speed)) / 20);
-            var speed_200_2100 = (byte)((200 + (19 * speed)) / 21);
+            byte rawSpeed = FanSpeedMapper.Map(_device._pid, speed);
 
             switch (_type)
             {
                 case Type.SL:
-                    _device.Write(new byte[] { 224, (byte)(32 + fancontroller_channel), 0, speed_800_1900 });
+                    _device.Write(new byte[] { 224, (byte)(32 + fancontroller_channel), 0, rawSpeed });
                     break;
                 case Type.SLV2:
-                    _device.Write(new byte[] { 224, (byte)(32 + fancontroller_channel), 0, speed_250_2000 });
+                    _device.Write(new byte[] { 224, (byte)(32 + fancontroller_channel), 0, rawSpeed });
                     break;
                 case Type.AL:
-                    _device.Write(new byte[] { 224, (byte)(32 + fancontroller_channel), 0, speed_800_1900 });
+                    _device.Write(new byte[] { 224, (byte)(32 + fancontroller_channel), 0, rawSpeed });
                     break;
                 case Type.ALV2:
-                    _device.Write(new byte[] { 224, (byte)(32 + fancontroller_channel), 0, speed_250_2000 });
+                    _device.Write(new byte[] { 224, (byte)(32 + fancontroller_channel), 0, rawSpeed });
                     break;
                 case Type.SLI:
-                    _device.Write(new byte[] { 224, (byte)(32 + fancontroller_channel), 0, speed_200_2100 });
+                    _device.Write(new byte[] { 224, (byte)(32 + fancontroller_channel), 0, rawSpeed });
                     break;
             }
         }

--- a/src/LianLiPlugin/LianLi/FanSpeedMapper.cs
+++ b/src/LianLiPlugin/LianLi/FanSpeedMapper.cs
@@ -1,0 +1,53 @@
+using System;
+
+namespace LianLi
+{
+    internal static class FanSpeedMapper
+    {
+        internal const int OriginalSlA100Minimum = 10;
+
+        public static byte Map(int productId, float requestedPercentage)
+        {
+            int percentage = NormalizePercentage(requestedPercentage);
+            int rawSpeed;
+
+            switch (productId)
+            {
+                case 0xa100:
+                    rawSpeed = percentage == 0
+                        ? OriginalSlA100Minimum
+                        : (800 + (11 * percentage)) / 19;
+                    break;
+                case 0x7750:
+                case 0xa101:
+                    rawSpeed = (800 + (11 * percentage)) / 19;
+                    break;
+                case 0xa103:
+                case 0xa104:
+                case 0xa105:
+                    rawSpeed = (int)((250 + (17.5 * percentage)) / 20);
+                    break;
+                case 0xa102:
+                    rawSpeed = (200 + (19 * percentage)) / 21;
+                    break;
+                default:
+                    return 100;
+            }
+
+            // Never emit a stop-like or out-of-protocol value.
+            return rawSpeed >= 1 && rawSpeed <= 100
+                ? (byte)rawSpeed
+                : (byte)100;
+        }
+
+        private static int NormalizePercentage(float requestedPercentage)
+        {
+            if (float.IsNaN(requestedPercentage) || float.IsInfinity(requestedPercentage))
+            {
+                return 100;
+            }
+
+            return (int)Math.Max(0, Math.Min(100, requestedPercentage));
+        }
+    }
+}

--- a/src/LianLiPlugin/Sensors.cs
+++ b/src/LianLiPlugin/Sensors.cs
@@ -36,7 +36,7 @@ namespace FanControl.LianLiPlugin
         {
             if(_val != val)
             {
-                _devices.FanControllers_SetSpeed(_controllerIndex, _channelIndex, (int)val);
+                _devices.FanControllers_SetSpeed(_controllerIndex, _channelIndex, val);
                 _val = val;
             }
         }

--- a/tests/FanControl.LianLiPlugin.Tests/FanControl.LianLiPlugin.Tests.csproj
+++ b/tests/FanControl.LianLiPlugin.Tests/FanControl.LianLiPlugin.Tests.csproj
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{E3B23066-E5A2-4B47-B999-C92C83C15994}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>FanControl.LianLiPlugin.Tests</RootNamespace>
+    <AssemblyName>FanControl.LianLiPlugin.Tests</AssemblyName>
+    <TargetFrameworkVersion>v4.8.1</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <Deterministic>true</Deterministic>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Program.cs" />
+    <Compile Include="..\..\src\LianLiPlugin\LianLi\FanSpeedMapper.cs">
+      <Link>FanSpeedMapper.cs</Link>
+    </Compile>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/tests/FanControl.LianLiPlugin.Tests/Program.cs
+++ b/tests/FanControl.LianLiPlugin.Tests/Program.cs
@@ -1,0 +1,100 @@
+using LianLi;
+using System;
+using System.Collections.Generic;
+
+namespace FanControl.LianLiPlugin.Tests
+{
+    internal static class Program
+    {
+        private static int _assertions;
+
+        private static int Main()
+        {
+            try
+            {
+                TestOriginalSlA100Mapping();
+                TestOtherModelsRemainUnchanged();
+                TestBoundsAndMonotonicity();
+
+                Console.WriteLine($"PASS: {_assertions} assertions");
+                return 0;
+            }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine("FAIL: " + ex.Message);
+                return 1;
+            }
+        }
+
+        private static void TestOriginalSlA100Mapping()
+        {
+            var expected = new Dictionary<int, byte>
+            {
+                { 0, 10 },
+                { 5, 45 },
+                { 10, 47 },
+                { 20, 53 },
+                { 50, 71 },
+                { 100, 100 }
+            };
+
+            foreach (KeyValuePair<int, byte> item in expected)
+            {
+                Equal(item.Value, FanSpeedMapper.Map(0xa100, item.Key), $"A100 {item.Key}%");
+            }
+        }
+
+        private static void TestOtherModelsRemainUnchanged()
+        {
+            Equal((byte)42, FanSpeedMapper.Map(0x7750, 0), "7750 0%");
+            Equal((byte)42, FanSpeedMapper.Map(0xa101, 0), "AL 0%");
+            Equal((byte)9, FanSpeedMapper.Map(0xa102, 0), "SL-Infinity 0%");
+            Equal((byte)12, FanSpeedMapper.Map(0xa103, 0), "SL V2 0%");
+            Equal((byte)12, FanSpeedMapper.Map(0xa104, 0), "AL V2 0%");
+            Equal((byte)12, FanSpeedMapper.Map(0xa105, 0), "SL V2 alternate PID 0%");
+        }
+
+        private static void TestBoundsAndMonotonicity()
+        {
+            int[] productIds = { 0x7750, 0xa100, 0xa101, 0xa102, 0xa103, 0xa104, 0xa105 };
+
+            foreach (int productId in productIds)
+            {
+                byte previous = 0;
+                for (int percentage = 0; percentage <= 100; percentage++)
+                {
+                    byte current = FanSpeedMapper.Map(productId, percentage);
+                    True(current > 0, $"PID {productId:x4} emitted raw zero");
+                    True(current >= previous, $"PID {productId:x4} decreased at {percentage}%");
+                    previous = current;
+                }
+
+                Equal((byte)100, previous, $"PID {productId:x4} full speed");
+            }
+
+            Equal((byte)10, FanSpeedMapper.Map(0xa100, -1), "negative input clamps to minimum");
+            Equal((byte)100, FanSpeedMapper.Map(0xa100, 101), "over-100 input clamps to full speed");
+            Equal((byte)100, FanSpeedMapper.Map(0xa100, float.NaN), "NaN fails safe");
+            Equal((byte)100, FanSpeedMapper.Map(0xa100, float.PositiveInfinity), "infinity fails safe");
+            Equal((byte)100, FanSpeedMapper.Map(0xffff, 0), "unknown PID fails safe");
+        }
+
+        private static void Equal<T>(T expected, T actual, string message)
+        {
+            _assertions++;
+            if (!EqualityComparer<T>.Default.Equals(expected, actual))
+            {
+                throw new InvalidOperationException($"{message}: expected {expected}, actual {actual}");
+            }
+        }
+
+        private static void True(bool condition, string message)
+        {
+            _assertions++;
+            if (!condition)
+            {
+                throw new InvalidOperationException(message);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Fix the minimum fan speed for the original UNI FAN SL controller with PID `A100`.

The existing percentage conversion maps Fan Control 0% to raw 42. USBPcap captures of L-Connect 3 showed that PID `A100` repeatedly sends raw 10 at its minimum setting and raw 100 at full speed.

## Hardware verification

Tested with one original UNI FAN SL hub containing:

- SL140 group: approximately 495 RPM at raw 10
- SL120 groups: approximately 780-810 RPM at raw 10

Captured minimum commands:

- Channel 1: `E0 20 00 0A`
- Channel 2: `E0 21 00 0A`
- Channel 3: `E0 22 00 0A`
- Channel 4: `E0 23 00 0A`

Full speed remained raw 100.

## Behavior

- PID `A100`: Fan Control 0% maps to raw 10.
- Values above 0% retain the existing mapping.
- PID `7750`, AL, SL-Infinity, SL V2, and AL V2 remain unchanged.
- Inputs are clamped to 0-100.
- NaN and infinity fail safe to full speed.
- No input produces raw zero.
- Every supported mapping is monotonic and 100% remains full speed.

## Scope

This PR is intentionally limited to the minimum-RPM mapping:

- Adds a small, testable PID-based speed mapper.
- Changes the speed call path to preserve the incoming floating-point value until normalization.
- Adds a dependency-free .NET Framework mapping test executable.
- Documents the captured commands and hardware results.

## Verification

- Debug build: passed
- Release build: passed
- Mapping tests: 1,438 assertions passed
- Hardware tested with PID `A100` and original SL120/SL140 fans